### PR TITLE
Add dev server config and use Let's Encrypt for TLS certificates

### DIFF
--- a/config/jupyterhub_config_dev.yaml
+++ b/config/jupyterhub_config_dev.yaml
@@ -49,6 +49,7 @@ proxy:
       #
       # Sleeping for 7 seconds has been consistently sufficient to avoid issues
       # in GKE when this workaround was explored initially for GKE.
+      # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2601#issuecomment-1127600794
       #
       - name: startup-delay
         image: busybox:stable

--- a/config/jupyterhub_config_dev.yaml
+++ b/config/jupyterhub_config_dev.yaml
@@ -1,0 +1,60 @@
+singleuser:
+  image:
+    tag: "2eaa1e5"
+    pullPolicy: "Always"
+    pullSecrets:
+      - name: image-pull-secret
+  cloudMetadata:
+    blockWithIptables: false
+  extraEnv:
+    JUPYTERHUB_PUBLIC_URL: https://dev.jupyter.chameleoncloud.org
+
+hub:
+  image:
+    tag: "a6e1f63"
+    pullPolicy: "Always"
+    pullSecrets:
+      - name: image-pull-secret
+  config:
+    ChameleonKeycloakAuthenticator:
+      keystone_auth_url: "https://dev.uc.chameleoncloud.org:5000/v3"
+      keystone_default_region_name: "CHI@UC"
+    GenericOAuthenticator:
+      oauth_callback_url: "https://dev.jupyter.chameleoncloud.org/hub/oauth_callback"
+      client_id: "jupyterhub-dev"
+      authorize_url: "https://auth.dev.chameleoncloud.org/auth/realms/chameleon/protocol/openid-connect/auth"
+      token_url: "https://auth.dev.chameleoncloud.org/auth/realms/chameleon/protocol/openid-connect/token"
+      userdata_url: "https://auth.dev.chameleoncloud.org/auth/realms/chameleon/protocol/openid-connect/userinfo"
+  extraEnv:
+    TROVI_URL: "https://trovi-dev.chameleoncloud.org"
+    KEYCLOAK_CLIENT_ID: "jupyterhub-dev"
+    KEYCLOAK_TOKEN_URL: "https://auth.dev.chameleoncloud.org/auth/realms/chameleon/protocol/openid-connect/token"
+    OAUTH_CLIENT_ID: "jupyterhub-dev"
+debug:
+  enabled: true
+proxy:
+  https:
+    enabled: true
+    hosts:
+      - dev.jupyter.chameleoncloud.org
+    letsencrypt:
+      contactEmail: contact@chameleoncloud.org
+  service:
+    loadBalancerIP: 34.132.247.78
+  traefik:
+    extraInitContainers:
+      # This startup delay can help the k8s container network interface setup
+      # network routing of traffic to the pod, which is essential for the ACME
+      # challenge submitted by Traefik on startup to acquire a TLS certificate.
+      #
+      # Sleeping for 7 seconds has been consistently sufficient to avoid issues
+      # in GKE when this workaround was explored initially for GKE.
+      #
+      - name: startup-delay
+        image: busybox:stable
+        command: ["sh", "-c", "sleep 20"]
+scheduling:
+  podPriority:
+    enabled: true
+  userPlaceholder:
+    replicas: 0

--- a/config/jupyterhub_config_prod.yaml
+++ b/config/jupyterhub_config_prod.yaml
@@ -37,16 +37,12 @@ proxy:
     enabled: true
     hosts:
       - jupyter.chameleoncloud.org
-    type: secret
-    secret:
-      name: jupyter-tls
-        #letsencrypt:
-        #contactEmail: markpowers@uchicago.edu
-        #acmeServer: https://acme-staging-v02.api.letsencrypt.org/directory
+    letsencrypt:
+      contactEmail: contact@chameleoncloud.org
   service:
     loadBalancerIP: 35.222.2.114
-      #traefik:
-      #extraInitContainers:
+  traefik:
+    extraInitContainers:
       # This startup delay can help the k8s container network interface setup
       # network routing of traffic to the pod, which is essential for the ACME
       # challenge submitted by Traefik on startup to acquire a TLS certificate.
@@ -54,24 +50,11 @@ proxy:
       # Sleeping for 7 seconds has been consistently sufficient to avoid issues
       # in GKE when this workaround was explored initially for GKE.
       #
-      #- name: startup-delay
-      #  image: busybox:stable
-      #  command: ["sh", "-c", "sleep 10"]
+      - name: startup-delay
+        image: busybox:stable
+        command: ["sh", "-c", "sleep 20"]
 scheduling:
   podPriority:
     enabled: true
   userPlaceholder:
     replicas: 2
-
-#ingress:
-#  enabled: true 
-#  hosts: 
-#      - jupyter.chameleoncloud.org
-#  tls:
-#  - hosts:
-#      - jupyter.chameleoncloud.org
-#    secretName:  jupyterhub-tls
-#  annotations: 
-#    cert-manager.io/cluster-issuer: letsencrypt
-#    kubernetes.io/tls-acme: "true"
-

--- a/deploy_dev.sh
+++ b/deploy_dev.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+export USE_GKE_GCLOUD_AUTH_PLUGIN=True
+
+#gcloud auth login
+
+gcloud container clusters get-credentials jupyter-dev --zone us-central1
+
+helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+helm repo update
+
+helm upgrade --cleanup-on-fail \
+	--install jupyter-dev jupyterhub/jupyterhub \
+	--namespace jupyter-dev \
+	--create-namespace \
+	--version=2.0.0 \
+	--values ./config/jupyterhub_config.yaml \
+	--values ./config/jupyterhub_secrets.yaml \
+	--values ./config/jupyterhub_config_dev.yaml
+


### PR DESCRIPTION
- Add deploy script and config for dev server
- Add delay to proxy startup in prod config

This patch adds a config for a Jupyter dev server, which was used to test the Let's Encrypt config. This change is ported to the prod config.
